### PR TITLE
Update Chrome mac driver and instructions

### DIFF
--- a/bin/webdrivers/chrome/README.md
+++ b/bin/webdrivers/chrome/README.md
@@ -17,9 +17,9 @@ For Windows:
 -Dwebdriver.chrome.driver=.\\vendor\\joomla-projects\\selenium-server-standalone\\bin\\webdrivers\\chrome\\chromedriver.exe
 ```
 
-For Mac:
+For Mac (v2.24.0):
 ```
--Dwebdriver.chrome.driver=.\\vendor\\joomla-projects\\selenium-server-standalone\\bin\\webdrivers\\chrome\\chromedriver_mac
+-Dwebdriver.chrome.driver=./vendor/joomla-projects/selenium-server-standalone/bin/webdrivers/chrome/chromedriver_mac -debug
 ```
 
 For Linux:


### PR DESCRIPTION
I found that with previous instructions Mac is not able to locate the Chrome driver when running Selenium.

I have fixed the instructions and update chrome driver to version 2.24

Here is a proof of it working: https://www.youtube.com/watch?v=wYW3G82Y2g4

Please note that I'm updating the Chrome driver from 2.23 to 2.24 only in Mac. If someone can test in his local please update the Windows and Linux versions downloading it from here: https://sites.google.com/a/chromium.org/chromedriver/downloads

cc: @810, @yvesh, @puneet0191
